### PR TITLE
Little parse/unparse structure change for ProductInfo tag

### DIFF
--- a/src/com/codeazur/as3swf/tags/TagProductInfo.as
+++ b/src/com/codeazur/as3swf/tags/TagProductInfo.as
@@ -6,12 +6,13 @@
 	{
 		public static const TYPE:uint = 41;
 		
+		private static const UINT_MAX_CARRY:Number = uint.MAX_VALUE + 1;
+
 		public var productId:uint;
 		public var edition:uint;
 		public var majorVersion:uint;
 		public var minorVersion:uint;
-		public var majorBuild:uint;
-		public var minorBuild:uint;
+		public var build:Number;
 		public var compileDate:Date;
 		
 		public function TagProductInfo() {}
@@ -21,10 +22,13 @@
 			edition = data.readUI32();
 			majorVersion = data.readUI8();
 			minorVersion = data.readUI8();
-			minorBuild = data.readUI32();
-			majorBuild = data.readUI32();
-			var sec:Number = data.readUI32();
-			sec += data.readUI32() * 4294967296;
+
+			build = data.readUI32()
+					+ data.readUI32() * UINT_MAX_CARRY;
+
+			var sec:Number = data.readUI32()
+					+ data.readUI32() * UINT_MAX_CARRY;
+
 			compileDate = new Date(sec);
 		}
 		
@@ -34,10 +38,10 @@
 			body.writeUI32(edition);
 			body.writeUI8(majorVersion);
 			body.writeUI8(minorVersion);
-			body.writeUI32(minorBuild);
-			body.writeUI32(majorBuild);
-			body.writeUI32(uint(compileDate.time));
-			body.writeUI32(uint(compileDate.time / 4294967296));
+			body.writeUI32(build);
+			body.writeUI32(build / UINT_MAX_CARRY);
+			body.writeUI32(compileDate.time);
+			body.writeUI32(compileDate.time / UINT_MAX_CARRY);
 			data.writeTagHeader(type, body.length);
 			data.writeBytes(body);
 		}
@@ -50,7 +54,7 @@
 			return toStringMain(indent) +
 				"ProductID: " + productId + ", " +
 				"Edition: " + edition + ", " +
-				"Version: " + majorVersion + "." + minorVersion + "." + majorBuild + "." + minorBuild + ", " +
+				"Version: " + majorVersion + "." + minorVersion + " r" + build + ", " +
 				"CompileDate: " + compileDate.toString();
 		}
 	}


### PR DESCRIPTION
For instance, if a SWF generated by Flex SDK 3.4.1, actually, we couldn't get the last version number "1".

The change has been made according the code below:

<pre><code>public void productInfo(ProductInfo tag)
{
    tagw.write32( tag.getProduct() );
    tagw.write32( tag.getEdition() );
    tagw.write( new byte[] { tag.getMajorVersion(), tag.getMinorVersion() } );
    tagw.write64( tag.getBuild() );
    tagw.write64( tag.getCompileDate() );
    encodeTag(tag);
}
</code></pre>


via [TagEncoder.java](http://opensource.adobe.com/svn/opensource/flex/sdk/tags/3.5.0.12683/modules/swfutils/src/java/flash/swf/TagEncoder.java)
