### PR TITLE
I found a small (but important) bug having to do with exporting shapes multiple times

### DIFF
--- a/src/com/codeazur/as3swf/data/SWFShape.as
+++ b/src/com/codeazur/as3swf/data/SWFShape.as
@@ -192,6 +192,9 @@
 		}
 		
 		public function export(handler:IShapeExporter = null):void {
+			// Reset the flag so that shapes can be exported multiple times
+			edgeMapsCreated = false;
+			
 			// Create edge maps
 			createEdgeMaps();
 			// If no handler is passed, default to DefaultShapeExporter (does nothing)


### PR DESCRIPTION
Fixed a bug where shapes that were exported more than once came out black
