### PR TITLE
add fix for actual dynamic text parsing behavior

### DIFF
--- a/src/com/codeazur/as3swf/tags/TagDefineEditText.as
+++ b/src/com/codeazur/as3swf/tags/TagDefineEditText.as
@@ -73,7 +73,7 @@
 			if (hasFontClass) {
 				fontClass = data.readString();
 			}
-			if (hasFont) {
+			if (hasFont || hasFontClass) {
 				fontHeight = data.readUI16();
 			}
 			if (hasTextColor) {


### PR DESCRIPTION
despite what the docs say, the actual parsing behavior must look for a fontHeight if either hasFont or hasFontClass is true